### PR TITLE
Change views to stop using AnyView as a Wrapper

### DIFF
--- a/BaseCalc/Views/ComplementAlert.swift
+++ b/BaseCalc/Views/ComplementAlert.swift
@@ -13,12 +13,10 @@ struct ComplementAlert: View {
     @EnvironmentObject var calculatorState: CalculatorState
 
     var body: some View {
-        GeneralAlert(
-            isShowing: manager.isShowing
-        ){ () -> AnyView in
-            AnyView(ComplementAlertContent(
+        GeneralAlert(isShowing: manager.isShowing) {
+            ComplementAlertContent(
                 digitValue: String(self.calculatorState.currentText.count)
-            ))
+            )
         }
     }
 }

--- a/BaseCalc/Views/FloatingPointAlert.swift
+++ b/BaseCalc/Views/FloatingPointAlert.swift
@@ -13,12 +13,10 @@ struct FloatingPointAlert: View {
     @EnvironmentObject var manager: FloatingPointAlertManager
     
     var body: some View {
-        GeneralAlert(
-            isShowing: manager.isShowing
-        ){ () -> AnyView in
-            AnyView(FloatingPointAlertContent(
+        GeneralAlert(isShowing: manager.isShowing) {
+            FloatingPointAlertContent(
                 number: Number(number: self.calculatorState.currentText, base: self.calculatorState.currentBase)
-            ))
+            )
         }
     }
 }

--- a/BaseCalc/Views/GeneralAlert.swift
+++ b/BaseCalc/Views/GeneralAlert.swift
@@ -8,14 +8,11 @@
 
 import SwiftUI
 
-struct GeneralAlert: View {
-    let Content: () -> AnyView;
+struct GeneralAlert<Content: View>: View {
+    let Content: () -> Content
     let isShowing: Bool
     
-    init(bgColor: Color = Color.black,
-         isShowing: Bool,
-         Content: @escaping () -> AnyView
-    ) {
+    init(isShowing: Bool, Content: @escaping () -> Content) {
         self.isShowing = isShowing
         self.Content = Content
     }
@@ -24,8 +21,8 @@ struct GeneralAlert: View {
         GeneralPopUpView(
             transition: AnyTransition.scale(scale: 0.95).combined(with: .opacity),
             isShowing: isShowing
-        ) { () -> AnyView in
-            AnyView(GeometryReader { geometry in
+        ) {
+            GeometryReader { geometry in
                 VStack {
                     ZStack(alignment: .center){
                         Color.alertBG
@@ -44,7 +41,7 @@ struct GeneralAlert: View {
                     Spacer()
                         .frame(height: geometry.size.width * 0.75)
                 }
-            })
+            }
         }
     }
 }

--- a/BaseCalc/Views/GeneralPopUpView.swift
+++ b/BaseCalc/Views/GeneralPopUpView.swift
@@ -8,19 +8,19 @@
 
 import SwiftUI
 
-struct GeneralPopUpView: View {
+struct GeneralPopUpView<Content: View>: View {
     let isShowing: Bool;
-    let Content: () -> AnyView;
+    let view: () -> Content;
     let transition: AnyTransition
     let bgColor: Color
 
     init(bgColor: Color = Color.black,
          transition: AnyTransition = .move(edge: .bottom),
          isShowing: Bool,
-         Content: @escaping () -> AnyView
+         view: @escaping () -> Content
     ) {
         self.isShowing = isShowing
-        self.Content = Content
+        self.view = view
         self.transition = transition
         self.bgColor = bgColor
     }
@@ -31,9 +31,9 @@ struct GeneralPopUpView: View {
                 bgColor
                      .edgesIgnoringSafeArea(.all)
                      .opacity(0.75)
-                Content()
-                .transition(transition)
-                .animation(.default)
+                view()
+                    .transition(transition)
+                    .animation(.default)
             }
         }.animation(.default)
     }

--- a/BaseCalc/Views/PopUpPickerView.swift
+++ b/BaseCalc/Views/PopUpPickerView.swift
@@ -12,8 +12,8 @@ struct PopUpPickerView: View {
     @EnvironmentObject var manager: PopUpPickerViewManager
 
     var body: some View {
-        GeneralPopUpView(isShowing: manager.isShowing) { () -> AnyView in
-            AnyView(GeometryReader { (geometry) in
+        GeneralPopUpView(isShowing: manager.isShowing) {
+            GeometryReader { (geometry) in
                 VStack {
                     Spacer()
                     PickerViewWithDoneToolbar().frame(
@@ -21,7 +21,7 @@ struct PopUpPickerView: View {
                     )
                 }
                 .edgesIgnoringSafeArea(.bottom)
-            })
+            }
         }
     }
 }


### PR DESCRIPTION
_title_

### Why?

It reduces an unnecessary wrapper, thus having a less complex App and creating less overhead