### PR TITLE
Allow for chaining of operations and printing of intermediate results

### DIFF
--- a/BaseCalc/EnvironmentalObjects.swift
+++ b/BaseCalc/EnvironmentalObjects.swift
@@ -98,9 +98,14 @@ class CalculatorState: ObservableObject {
         if prevOperation != nil {
             solve()
         }
-        
-        willPerformOperation = true
+
         prevOperation = op
+
+        if op == .leftShift1 || op == .rightShift1 {
+            solve()
+        } else {
+            willPerformOperation = true
+        }
     }
     
     func isOperationSelected(op: Operation) -> Bool {
@@ -123,11 +128,6 @@ class CalculatorState: ObservableObject {
         currentText = currNumber.toString(base: newBase)
         hasDecimalDot = currNumber.hasFract
         currentBase = newBase
-    }
-
-    func performSingleShift(shift: Operation){
-        prevOperation = shift
-        solve()
     }
 
     func solve() {

--- a/BaseCalc/Views/KeypadButton.swift
+++ b/BaseCalc/Views/KeypadButton.swift
@@ -105,7 +105,7 @@ struct KeypadButton: View {
 
     func makeSingleShiftButton(op: Operation) -> AnyView {
         let disabled = calculatorState.isInvalidForBitOperations()
-        let callback = { self.calculatorState.performSingleShift(shift: op) }
+        let callback = { self.calculatorState.performOperation(op: op) }
         return AnyView(Button(action: generalAction(callback)) {
             Text(label)
                 .modifier(DarkGrayButton(width: width, height: height, altCondition: disabled))

--- a/BaseCalcTests/CalculatorStateTests.swift
+++ b/BaseCalcTests/CalculatorStateTests.swift
@@ -139,19 +139,9 @@ class CalculatorStateTests: XCTestCase {
         numericalOperationsAux(nor, "NOR")
     }
 
-    func testLeftShift1() {
-        let leftShift1 = { self.state.performOperation(op: .leftShift1) }
-        numericalOperationsAux(leftShift1, "<<")
-    }
-
     func testLeftShiftN() {
         let leftShiftN = { self.state.performOperation(op: .leftShiftN) }
         numericalOperationsAux(leftShiftN, "X<<Y")
-    }
-
-    func testRightShift1() {
-        let rightShift1 = { self.state.performOperation(op: .rightShift1) }
-        numericalOperationsAux(rightShift1, ">>")
     }
 
     func testRightShiftN() {


### PR DESCRIPTION
_title_

### **`testLeftShift1` and `testRightShift1` have been removed. Why?**
The tests were designed to validate if CalculatorState retained operations. However, after refactoring, `leftShift1` and `rightShift1` are solved immediately in `performOperation` and state doesn't need to be stored (they do not require a second operand and as such can be solved on the spot, no pending tasks).