### PR TITLE
Fix bug that wouldn't allow operation change

### DIFF
--- a/BaseCalc/EnvironmentalObjects.swift
+++ b/BaseCalc/EnvironmentalObjects.swift
@@ -97,7 +97,7 @@ class CalculatorState: ObservableObject {
     }
 
     func performOperation(op: Operation) {
-        if prevOperation != nil {
+        if prevOperation != nil && !willPerformOperation {
             solve()
         }
 

--- a/BaseCalcTests/CalculatorStateTests.swift
+++ b/BaseCalcTests/CalculatorStateTests.swift
@@ -117,6 +117,16 @@ class CalculatorStateTests: XCTestCase {
         numericalOperationsAux(divide, "÷")
     }
 
+    func testOperationChange() {
+        state.addDigit("2")
+        testSum()
+        testMultiplication()
+        XCTAssertEqual(state.currentText, "2")
+        state.addDigit("4")
+        state.solve()
+        XCTAssertEqual(state.currentText, "8")
+    }
+
     //MARK:- Bitwise operations
 
     func testAnd() {


### PR DESCRIPTION
### Fix bug that wouldn't allow operation change

**Steps to trigger**
1. Type a number
2. Select an operation
3. Select another operation

**What happens**
The calculator solves the first operation using the number twice (as the user hasn't inserted a second number) and then selects the second operation as the next one to perform.

**What was expected**
The calculator would switch between operations to perform from the first selected operation to the second one, without calculating anything in between.

**When was bug introduced**
As part of #35, a criteria for intermediate operations was introduced that performs an operation if there is a pending one. It did not check, however, that a second number was introduced and, as such, switching between operations was considered an intermediate operation that needed to be performed.

**Fix**
Check that willPerformOperation is inactive when checking if there is a prevOperation, as this flag is deactivated when the second number is entered by the user. Tests have been added to ensure that the feature remains functional.